### PR TITLE
Use CSS for uppercase instead of hard-coding ALLCAPS

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,15 +23,15 @@ export default function Home() {
                     <h1 className="green-text xs:text-6xl mt-6 ml-2 pr-2 text-5xl font-bold tracking-[-0.09em] md:mt-4 md:text-8xl">
                         PrivacyPack
                     </h1>
-                    <p className="xs:text-lg mt-4 flex flex-col text-center text-base font-semibold tracking-tighter text-white/50 md:text-2xl">
-                        YOUR PRIVACY WINS, IN ONE CARD
+                    <p className="xs:text-lg mt-4 flex flex-col text-center text-base font-semibold tracking-tighter text-white/50 md:text-2xl uppercase">
+                        Your privacy wins, in one card
                     </p>
                     <Link
                         href="/create"
                         id="create-pack"
-                        className="mt-12 items-center justify-center rounded-2xl bg-white px-10 py-4 text-base font-semibold text-black transition-all duration-150 hover:bg-white/80"
+                        className="mt-12 items-center justify-center rounded-2xl bg-white px-10 py-4 text-base font-semibold text-black transition-all duration-150 hover:bg-white/80 uppercase"
                     >
-                        CREATE YOUR PACK
+                        Create your Pack
                     </Link>
                 </div>
             </div>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -4,7 +4,7 @@ const Privacy = () => {
     return (
         <div className="flex w-screen flex-col items-center">
             <div className="flex w-full flex-col gap-5 p-8 text-gray-400 lg:w-[56rem] lg:p-16">
-                <h1 className="mb-8 text-3xl text-white">PRIVACY POLICY</h1>
+                <h1 className="mb-8 text-3xl text-white uppercase">Privacy Policy</h1>
                 <p>Last Updated: August 23, 2025</p>
                 <p>
                     We respect the privacy of our Users (&quot;User&quot;,

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -4,8 +4,8 @@ const Terms = () => {
     return (
         <div className="flex w-screen flex-col items-center">
             <div className="flex w-full flex-col gap-5 p-8 text-gray-400 lg:w-[56rem] lg:p-16">
-                <h1 className="mb-8 text-3xl text-white">
-                    TERMS AND CONDITIONS
+                <h1 className="mb-8 text-3xl text-white uppercase">
+                    Terms and Conditions
                 </h1>
                 <p>Last Updated: August 23, 2025</p>
                 <p>


### PR DESCRIPTION
The stylistic choice of ALLCAPS words should be done on CSS level, not by writing the actual words like that. This way, screen readers and other accessibility tools get the regular version.