### PR TITLE
Removed ICloud Keychain. This is an engine, Apple Passwords is the app

### DIFF
--- a/data/apps.json
+++ b/data/apps.json
@@ -141,7 +141,6 @@
             "order": 8,
             "mainstream_apps": [
                 { "id": "google_passwords", "name": "Google Passwords" },
-                { "id": "icloud_keychain", "name": "iCloud Keychain" },
                 { "id": "samsung_pass", "name": "Samsung Pass" },
                 { "id": "lastpass", "name": "LastPass" },
                 { "id": "apple_passwords", "name": "Apple Passwords" },


### PR DESCRIPTION
Removed ICloud keychain.

The logo was missing and also, ICloud keychain is the engine. Apple Passwords is the user faced app which is already in main code.

Changelog:

apps.json:
Removed ICloud Keychain

<img width="592" height="770" alt="image" src="https://github.com/user-attachments/assets/8a554a20-8b71-4dd3-83d4-5881112c7616" />
