### PR TITLE
Here WeGo" as Private alternative for Maps

### DIFF
--- a/data/apps.json
+++ b/data/apps.json
@@ -274,6 +274,7 @@
                 { "id": "kagi", "name": "Kagi Maps" },
                 { "id": "magic_earth", "name": "Magic Earth" },
                 { "id": "osmand", "name": "OsmAnd" }
+                { "id": "here_wego", "name": "HERE WeGo" }
             ]
         },
         {


### PR DESCRIPTION

![here_we_go_logo](https://github.com/user-attachments/assets/dd27e001-9623-449c-b5ae-e91cc508125e)
Added "Here WeGo" as Private alternative for Maps
I was not able to add the picture in the mentioned folder.