### PR TITLE
Jottacloud as Photo storage

### DIFF
--- a/data/apps.json
+++ b/data/apps.json
@@ -30,6 +30,7 @@
                 { "id": "dropbox", "name": "Dropbox" }
             ],
             "private_alternatives": [
+				{ "id": "jottacloud", "name": "Jottacloud" },
                 { "id": "ente_photos", "name": "Ente Photos" },
                 { "id": "proton_drive", "name": "Proton Drive" },
                 { "id": "immich", "name": "Immich" },


### PR DESCRIPTION
[Jottacloud](jottacloud.com/de/) was already added as a cloud drive service, but it has Photo upload features, gallery and map view and even simple search features, which makes it more capable than Filen and Proton Drive which are added as photo backup services. Only feels appropriate to list it twice as well.