### PR TITLE
Add Video Conferencing, Office Suite categories and missing privacy t…

### DIFF
--- a/data/apps.json
+++ b/data/apps.json
@@ -428,13 +428,14 @@
             "order": 24,
             "mainstream_apps": [
                 { "id": "google_docs", "name": "Google Docs" },
+                { "id": "google_sheets", "name": "Google Sheets" },
                 { "id": "microsoft_office", "name": "Microsoft Office" }
             ],
             "private_alternatives": [
                 { "id": "cryptpad", "name": "CryptPad" },
                 { "id": "libreoffice", "name": "LibreOffice" },
-                { "id": "ddocs", "name": "DDocs" },
-                { "id": "onlyoffice", "name": "OnlyOffice" }
+                { "id": "onlyoffice", "name": "OnlyOffice" },
+                { "id": "proton_docs", "name": "Proton Docs" }
             ]
         }
     ]


### PR DESCRIPTION
New Categories
Video Conferencing (order: 23)
Mainstream: Zoom, Google Meet, Microsoft Teams, Webex Private alternatives: Brave Talk, Signal Video

Office Suite (order: 24)
Mainstream: Google Docs, Microsoft Office
Private alternatives: CryptPad, LibreOffice, DDocs, OnlyOffice

Additions to Existing Categories

AI Assistant
- Brave Leo

Translator
- Brave Translate

Computer OS
- secureblue
- Tails
- Whonix