### PR TITLE
Add Fileverse dDocs/dSheets to privacy office apps

### DIFF
--- a/data/apps.json
+++ b/data/apps.json
@@ -437,7 +437,8 @@
                 { "id": "Collabora", "name": "Collabora" },
                 { "id": "OnlyOffice", "name": "OnlyOffice" },
                 { "id": "OpenOffice", "name": "OpenOffice" },
-                { "id": "CryptPad", "name": "CryptPad" }
+                { "id": "CryptPad", "name": "CryptPad" },
+                { "id": "fileverse", "name": "Fileverse dDocs/dSheets"}
              ]
         }
     ]


### PR DESCRIPTION
dDocs was already listed in the note-taking section but it also fits the office section. Fileverse also makes a spreadsheet app called dSheets (https://dsheets.new).