### PR TITLE
Add Megatech Photos to apps.json

### DIFF
--- a/data/apps.json
+++ b/data/apps.json
@@ -40,7 +40,8 @@
                 { "id": "zeitkapsl", "name": "zeitkapsl" },
                 { "id": "filen", "name": "Filen" },
                 { "id": "photoprism", "name": "PhotoPrism" },
-                { "id": "murena_workspace", "name": "Murena Gallery" }
+                { "id": "murena_workspace", "name": "Murena Gallery" },
+                { "id": "megatech_photos", "name": "Megatech Photos" }
             ]
         },
         {


### PR DESCRIPTION
Megatech Photos is a privacy-focused, end-to-end encrypted Google Photos alternative offering 20 GB of free storage. Files are encrypted on the user’s device before upload, ensuring the service cannot access your photos. Adds Megatech Photos as a private alternative to mainstream photo apps like Google Photos and Apple Photos.